### PR TITLE
LIST RW query implemented on mock server

### DIFF
--- a/NUTDotNetServer/NUTDotNetServer.csproj
+++ b/NUTDotNetServer/NUTDotNetServer.csproj
@@ -5,8 +5,8 @@
     <Version>0.0.0.0</Version>
     <Authors />
     <Company />
-    <AssemblyVersion>0.1.44.21047</AssemblyVersion>
-    <FileVersion>0.1.44.21047</FileVersion>
+    <AssemblyVersion>0.1.47.21048</AssemblyVersion>
+    <FileVersion>0.1.47.21048</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NUTDotNetServer/NUTServer.cs
+++ b/NUTDotNetServer/NUTServer.cs
@@ -210,23 +210,10 @@ namespace NUTDotNetServer
                         response.Append(ups + NUTCommon.NewLine);
                     response.Append("END LIST UPS" + NUTCommon.NewLine);
                 }
-                else if (dividedQuery[0].Equals("VAR"))
+                else if (dividedQuery.Length == 2 && (dividedQuery[0].Equals("VAR") || dividedQuery[0].Equals("RW"))
+                    && !dividedQuery[1].Equals(string.Empty))
                 {
-                    if (dividedQuery.Length == 1 || dividedQuery[1].Equals(string.Empty))
-                        throw new Exception();
-
-                    UPS upsObject = GetUPSByName(dividedQuery[1]);
-                    if (upsObject is null)
-                    {
-                        response.Clear();
-                        response.Append("ERR UNKNOWN-UPS" + NUTCommon.NewLine);
-                    }
-                    else
-                    {
-                        response.Append("BEGIN LIST VAR " + dividedQuery[1] + NUTCommon.NewLine);
-                        response.Append(upsObject.VariablesToString());
-                        response.Append("END LIST VAR " + dividedQuery[1] + NUTCommon.NewLine);
-                    }
+                    DoDictionaryListQuery(dividedQuery[0], dividedQuery[1], response);
                 }
                 // Bad subquery provided.
                 else
@@ -241,6 +228,25 @@ namespace NUTDotNetServer
             }
 
             return response.ToString();
+        }
+
+        private void DoDictionaryListQuery(string subquery, string ups, StringBuilder sb)
+        {
+            UPS upsObject = GetUPSByName(ups);
+            if (upsObject is null)
+            {
+                sb.Clear();
+                sb.Append("ERR UNKNOWN-UPS" + NUTCommon.NewLine);
+            }
+            else
+            {
+                sb.AppendFormat("BEGIN LIST {0} {1}{2}", subquery, ups, NUTCommon.NewLine);
+                if (subquery.Equals("VAR"))
+                    sb.Append(upsObject.VariablesToString());
+                else if (subquery.Equals("RW"))
+                    sb.Append(upsObject.RewritablesToString());
+                sb.AppendFormat("END LIST {0} {1}{2}", subquery, ups, NUTCommon.NewLine);
+            }
         }
 
         public UPS GetUPSByName(string name)

--- a/NUTDotNetShared/NUTDotNetShared.csproj
+++ b/NUTDotNetShared/NUTDotNetShared.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>0.0.12.21047</AssemblyVersion>
-    <FileVersion>0.0.12.21047</FileVersion>
+    <AssemblyVersion>0.0.14.21048</AssemblyVersion>
+    <FileVersion>0.0.14.21048</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/NUTDotNetShared/UPS.cs
+++ b/NUTDotNetShared/UPS.cs
@@ -8,12 +8,14 @@ namespace NUTDotNetShared
         public readonly string Name;
         public readonly string Description;
         public Dictionary<string, string> Variables;
+        public Dictionary<string, string> Rewritables;
 
         public UPS(string name, string description = "Unavailable")
         {
             Name = name;
             Description = description;
             Variables = new Dictionary<string, string>();
+            Rewritables = new Dictionary<string, string>();
         }
 
         public override string ToString()
@@ -21,17 +23,33 @@ namespace NUTDotNetShared
             return "UPS " + Name + " \"" + Description + "\"";
         }
 
-        public string VariablesToString()
+        /// <summary>
+        /// Basic function that can put a common dictionary to string as the NUT protocol would expect it.
+        /// </summary>
+        /// <param name="nutName">The type of data a NUT protocol device would expect, such as VAR or RW</param>
+        /// <param name="dictionary">The dictionary to be parsed.</param>
+        /// <returns></returns>
+        private string DictionaryToString(string nutName, Dictionary<string, string> dictionary)
         {
-            if (Variables.Count == 0)
+            if (dictionary.Count == 0)
                 return NUTCommon.NewLine;
 
-            StringBuilder sb = new StringBuilder(Variables.Count);
-            foreach (KeyValuePair<string, string> variable in Variables)
+            StringBuilder sb = new StringBuilder(dictionary.Count);
+            foreach (KeyValuePair<string, string> variable in dictionary)
             {
-                sb.AppendFormat("VAR {0} {1} \"{2}\"{3}", Name, variable.Key, variable.Value, NUTCommon.NewLine);
+                sb.AppendFormat("{0} {1} {2} \"{3}\"{4}", nutName, Name, variable.Key, variable.Value, NUTCommon.NewLine);
             }
             return sb.ToString();
+        }
+
+        public string VariablesToString()
+        {
+            return DictionaryToString("VAR", Variables);
+        }
+
+        public string RewritablesToString()
+        {
+            return DictionaryToString("RW", Rewritables);
         }
     }
 }

--- a/Testing/Testing.csproj
+++ b/Testing/Testing.csproj
@@ -5,9 +5,9 @@
 
     <IsPackable>false</IsPackable>
 
-    <AssemblyVersion>1.0.96.21047</AssemblyVersion>
+    <AssemblyVersion>1.0.104.21048</AssemblyVersion>
 
-    <FileVersion>1.0.96.21047</FileVersion>
+    <FileVersion>1.0.104.21048</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Created a general function to handle dictionary-based queries
- Added RW dictionary to UPS class and made a generic function to stringify dictionaries.
- Added utility function to server testing to parse a list response.
- Changed LIST VAR test class to test general dictionary LIST tests, and added the RW tests in.
- Ref. issue #6.